### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -34,6 +34,10 @@ class ItemsController < ApplicationController
   end
 
   def destroy
+    if !@item.purchase_record && user_signed_in? && current_user.id == @item.user_id
+      @item.destroy
+    end
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!,  only: %i[new edit]
-  before_action :find_item,           only: %i[show edit update]
+  before_action :find_item,           only: %i[show edit update destroy]
 
   def index
     @items = Item.all.order(created_at: 'DESC').includes(:purchase_record)
@@ -31,6 +31,9 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -34,9 +34,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if !@item.purchase_record && user_signed_in? && current_user.id == @item.user_id
-      @item.destroy
-    end
+    @item.destroy if !@item.purchase_record && user_signed_in? && current_user.id == @item.user_id
     redirect_to root_path
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
-        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+        <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
       <% else %>
         <%= link_to '購入画面に進む', item_orders_path(@item.id), method: :get, class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: 'items#index'
-  resources :items, only: %i[index new create show edit update] do
+  resources :items do
     resources :orders, only: %i[index create]
   end
 end


### PR DESCRIPTION
# What
出品済みの商品を削除するための機能
# Why
手元にある商品の盗難や紛失など、なんらかの理由で出品した商品を取り消したい時に使うため
非ログイン状態のユーザーと出品者と異なるユーザーは削除ボタンが表示されないが、
念のため**コントローラーのdestroyアクション内でもif文によって削除できなくしている**
## Gyazo
- 出品者は購入者がいなければ出品した商品を削除ボタンで削除できる
https://gyazo.com/b960e08f86a299e220a40ed49dab6d10
- 未ログインユーザーと出品者と異なるユーザーは削除ボタンがないため削除できない
https://gyazo.com/dc95023e6b8ce18a6d4c1ac0a59b0c4e
- **出品者でも購入者の存在する商品は削除できない**
https://gyazo.com/5774e792b7abd83ec39ead9162a5deb2